### PR TITLE
Fix VS Code tasks and solution path

### DIFF
--- a/BitBetMatic/.vscode/tasks.json
+++ b/BitBetMatic/.vscode/tasks.json
@@ -1,60 +1,64 @@
 {
 	"version": "2.0.0",
 	"tasks": [
-		{
-			"label": "clean (functions)",
-			"command": "dotnet",
-			"args": [
-				"clean",
-				"/property:GenerateFullPaths=true",
-				"/consoleloggerparameters:NoSummary"
-			],
-			"type": "process",
-			"problemMatcher": "$msCompile"
-		},
-		{
-			"label": "build (functions)",
-			"command": "dotnet",
-			"args": [
-				"build",
-				"/property:GenerateFullPaths=true",
-				"/consoleloggerparameters:NoSummary"
-			],
-			"type": "process",
-			"dependsOn": "clean (functions)",
-			"group": {
-				"kind": "build",
-				"isDefault": true
-			},
-			"problemMatcher": "$msCompile"
-		},
-		{
-			"label": "clean release (functions)",
-			"command": "dotnet",
-			"args": [
-				"clean",
-				"--configuration",
-				"Release",
-				"/property:GenerateFullPaths=true",
-				"/consoleloggerparameters:NoSummary"
-			],
-			"type": "process",
-			"problemMatcher": "$msCompile"
-		},
-		{
-			"label": "publish (functions)",
-			"command": "dotnet",
-			"args": [
-				"publish",
-				"--configuration",
-				"Release",
-				"/property:GenerateFullPaths=true",
-				"/consoleloggerparameters:NoSummary"
-			],
-			"type": "process",
-			"dependsOn": "clean release (functions)",
-			"problemMatcher": "$msCompile"
-		},
+                {
+                        "label": "clean (functions)",
+                        "command": "dotnet",
+                        "args": [
+                                "clean",
+                                "${workspaceFolder}/BitBetMaticFunctions.csproj",
+                                "/property:GenerateFullPaths=true",
+                                "/consoleloggerparameters:NoSummary"
+                        ],
+                        "type": "process",
+                        "problemMatcher": "$msCompile"
+                },
+                {
+                        "label": "build (functions)",
+                        "command": "dotnet",
+                        "args": [
+                                "build",
+                                "${workspaceFolder}/BitBetMaticFunctions.csproj",
+                                "/property:GenerateFullPaths=true",
+                                "/consoleloggerparameters:NoSummary"
+                        ],
+                        "type": "process",
+                        "dependsOn": "clean (functions)",
+                        "group": {
+                                "kind": "build",
+                                "isDefault": true
+                        },
+                        "problemMatcher": "$msCompile"
+                },
+                {
+                        "label": "clean release (functions)",
+                        "command": "dotnet",
+                        "args": [
+                                "clean",
+                                "${workspaceFolder}/BitBetMaticFunctions.csproj",
+                                "--configuration",
+                                "Release",
+                                "/property:GenerateFullPaths=true",
+                                "/consoleloggerparameters:NoSummary"
+                        ],
+                        "type": "process",
+                        "problemMatcher": "$msCompile"
+                },
+                {
+                        "label": "publish (functions)",
+                        "command": "dotnet",
+                        "args": [
+                                "publish",
+                                "${workspaceFolder}/BitBetMaticFunctions.csproj",
+                                "--configuration",
+                                "Release",
+                                "/property:GenerateFullPaths=true",
+                                "/consoleloggerparameters:NoSummary"
+                        ],
+                        "type": "process",
+                        "dependsOn": "clean release (functions)",
+                        "problemMatcher": "$msCompile"
+                },
 		{
 			"type": "func",
 			"dependsOn": "build (functions)",

--- a/Crypto.sln
+++ b/Crypto.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.5.002.0
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BitBetMatic", "BitBetMatic\BitBetMatic.csproj", "{D6363BC6-74F0-4694-AE1D-AC469F7BF663}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BitBetMatic", "BitBetMatic\BitBetMaticFunctions.csproj", "{D6363BC6-74F0-4694-AE1D-AC469F7BF663}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution


### PR DESCRIPTION
## Summary
- fix incorrect project reference in `Crypto.sln`
- update VS Code tasks to specify the project path when cleaning, building and publishing

## Testing
- `dotnet restore BitBetMatic/BitBetMaticFunctions.csproj` *(fails: Restore canceled)*

------
https://chatgpt.com/codex/tasks/task_e_685907e798888323b70d793dde90b6e7