### PR TITLE
Refactor candle data access

### DIFF
--- a/BitBetMatic/Backtesting/BackTesting.cs
+++ b/BitBetMatic/Backtesting/BackTesting.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 using BitBetMatic;
 using BitBetMatic.API;
+using BitBetMatic.Repositories;
 using Newtonsoft.Json;
 using Skender.Stock.Indicators;
 
@@ -18,9 +19,9 @@ public class BackTesting
     private const double _maxDeviation = 50d;
     private const decimal _startingBalance = 300.0m;
 
-    public BackTesting(IApiWrapper api)
+    public BackTesting(IApiWrapper api, CandleRepository candleRepository)
     {
-        dataLoader = new DataLoader(api);
+        dataLoader = new DataLoader(api, candleRepository);
         indicatorThresholdPersistency = new IndicatorThresholdPersistency();
     }
 

--- a/BitBetMatic/Backtesting/BitvavoPerformanceFunction.cs
+++ b/BitBetMatic/Backtesting/BitvavoPerformanceFunction.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using BitBetMatic.API;
+using BitBetMatic.Repositories;
 using Skender.Stock.Indicators;
 using Microsoft.Azure.Functions.Worker.Http;
 
@@ -12,10 +13,10 @@ public class BitvavoPerformanceProcessor
     private readonly DataLoader dataLoader;
     private readonly PortfolioManager portfolioManager;
 
-    public BitvavoPerformanceProcessor(IApiWrapper apiWrapper)
+    public BitvavoPerformanceProcessor(IApiWrapper apiWrapper, CandleRepository candleRepository)
     {
         api = apiWrapper;
-        dataLoader = new DataLoader(api);
+        dataLoader = new DataLoader(api, candleRepository);
         portfolioManager = new PortfolioManager();
     }
 

--- a/BitBetMatic/Backtesting/Dataloader.cs
+++ b/BitBetMatic/Backtesting/Dataloader.cs
@@ -2,20 +2,30 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using BitBetMatic.API;
+using BitBetMatic.Repositories;
 
 public class DataLoader
 {
     private readonly IApiWrapper _api;
+    private readonly CandleRepository _candleRepository;
 
-    public DataLoader(IApiWrapper api)
+    public DataLoader(IApiWrapper api, CandleRepository candleRepository)
     {
         _api = api;
+        _candleRepository = candleRepository;
     }
 
     public async Task<List<FlaggedQuote>> LoadHistoricalData(string market, string interval, int limit, DateTime start, DateTime end)
     {
 
-        var quotes = await _api.GetCandleData(market, interval, limit, start, end);
-            return quotes;
+        var quotes = await _candleRepository.GetCandlesAsync(market, start, end);
+
+        if (quotes.Count == 0)
+        {
+            quotes = await _api.GetCandleData(market, interval, limit, start, end);
+            await _candleRepository.AddCandlesAsync(quotes);
+        }
+
+        return quotes;
     }
 }

--- a/BitBetMatic/BitBetMaticFunction.cs
+++ b/BitBetMatic/BitBetMaticFunction.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
 using BitBetMatic.API;
+using BitBetMatic.Repositories;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.EntityFrameworkCore;
@@ -85,7 +86,7 @@ namespace BitBetMatic
         private async Task FindPatterns()
         {
             // Voorbeeldlijst van Quotes
-            var dataLoader = new DataLoader(new BitvavoApi());
+            var dataLoader = new DataLoader(new BitvavoApi(), new CandleRepository());
 
             var start = DateTime.Today.AddDays(-2);
             var end = DateTime.Today;
@@ -118,35 +119,35 @@ namespace BitBetMatic
 
             var tasksModerateStrategy = new List<Task<(TradingStrategyBase strategy, string result)>>{
 
-                new BackTesting(new BitvavoApi()).DoBacktestDeepTuning<ModerateStrategy>(sb, BitBetMaticProcessor.BtcMarket, numberOfVariants),
-                new BackTesting(new BitvavoApi()).DoBacktestDeepTuning<ModerateStrategy>(sb, BitBetMaticProcessor.EthMarket, numberOfVariants),
+                new BackTesting(new BitvavoApi(), new CandleRepository()).DoBacktestDeepTuning<ModerateStrategy>(sb, BitBetMaticProcessor.BtcMarket, numberOfVariants),
+                new BackTesting(new BitvavoApi(), new CandleRepository()).DoBacktestDeepTuning<ModerateStrategy>(sb, BitBetMaticProcessor.EthMarket, numberOfVariants),
             };
 
             await Task.WhenAll(tasksModerateStrategy);
 
             var tasksAgressiveStrategy = new List<Task<(TradingStrategyBase strategy, string result)>>{
-                new BackTesting(new BitvavoApi()).DoBacktestDeepTuning<AgressiveStrategy>(sb, BitBetMaticProcessor.BtcMarket, numberOfVariants),
-                new BackTesting(new BitvavoApi()).DoBacktestDeepTuning<AgressiveStrategy>(sb, BitBetMaticProcessor.EthMarket, numberOfVariants),
+                new BackTesting(new BitvavoApi(), new CandleRepository()).DoBacktestDeepTuning<AgressiveStrategy>(sb, BitBetMaticProcessor.BtcMarket, numberOfVariants),
+                new BackTesting(new BitvavoApi(), new CandleRepository()).DoBacktestDeepTuning<AgressiveStrategy>(sb, BitBetMaticProcessor.EthMarket, numberOfVariants),
             };
 
             await Task.WhenAll(tasksAgressiveStrategy);
 
             var tasksScoredStrategy = new List<Task<(TradingStrategyBase strategy, string result)>>{
-                new BackTesting(new BitvavoApi()).DoBacktestDeepTuning<ScoredStrategy>(sb, BitBetMaticProcessor.BtcMarket, numberOfVariants),
-                new BackTesting(new BitvavoApi()).DoBacktestDeepTuning<ScoredStrategy>(sb, BitBetMaticProcessor.EthMarket, numberOfVariants),
+                new BackTesting(new BitvavoApi(), new CandleRepository()).DoBacktestDeepTuning<ScoredStrategy>(sb, BitBetMaticProcessor.BtcMarket, numberOfVariants),
+                new BackTesting(new BitvavoApi(), new CandleRepository()).DoBacktestDeepTuning<ScoredStrategy>(sb, BitBetMaticProcessor.EthMarket, numberOfVariants),
             };
 
             await Task.WhenAll(tasksScoredStrategy);
 
             var tasksStoplossStrategy = new List<Task<(TradingStrategyBase strategy, string result)>>{
-                new BackTesting(new BitvavoApi()).DoBacktestDeepTuning<StoplossStrategy>(sb, BitBetMaticProcessor.BtcMarket, numberOfVariants),
-                new BackTesting(new BitvavoApi()).DoBacktestDeepTuning<StoplossStrategy>(sb, BitBetMaticProcessor.EthMarket, numberOfVariants),
+                new BackTesting(new BitvavoApi(), new CandleRepository()).DoBacktestDeepTuning<StoplossStrategy>(sb, BitBetMaticProcessor.BtcMarket, numberOfVariants),
+                new BackTesting(new BitvavoApi(), new CandleRepository()).DoBacktestDeepTuning<StoplossStrategy>(sb, BitBetMaticProcessor.EthMarket, numberOfVariants),
             };
 
             await Task.WhenAll(tasksStoplossStrategy);
 
             var tasksAdvancedStrategy = new List<Task<(TradingStrategyBase strategy, string result)>>{
-                new BackTesting(new BitvavoApi()).DoBacktestDeepTuning<AdvancedStrategy>(sb, BitBetMaticProcessor.BtcMarket, numberOfVariants),
+                new BackTesting(new BitvavoApi(), new CandleRepository()).DoBacktestDeepTuning<AdvancedStrategy>(sb, BitBetMaticProcessor.BtcMarket, numberOfVariants),
                 // new BackTesting(new BitvavoApi()).DoBacktestDeepTuning<AdvancedStrategy>(sb, BitBetMaticProcessor.EthMarket, numberOfVariants),
             };
 

--- a/BitBetMatic/Repositories/CandleRepository.cs
+++ b/BitBetMatic/Repositories/CandleRepository.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using BitBetMatic.API;
+using Microsoft.EntityFrameworkCore;
+
+namespace BitBetMatic.Repositories
+{
+    public class CandleRepository
+    {
+        public async Task<List<FlaggedQuote>> GetCandlesAsync(string market, DateTime start, DateTime end)
+        {
+            using var context = new TradingDbContext();
+            start = DateTime.SpecifyKind(start, DateTimeKind.Utc);
+            end = DateTime.SpecifyKind(end, DateTimeKind.Utc);
+
+            return await context.Candles
+                .Where(c => c.Market == market && c.Date >= start && c.Date <= end)
+                .OrderBy(c => c.Date)
+                .ToListAsync();
+        }
+
+        public async Task AddCandlesAsync(IEnumerable<FlaggedQuote> candles)
+        {
+            using var context = new TradingDbContext();
+            await context.Candles.AddRangeAsync(candles);
+            await context.SaveChangesAsync();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `CandleRepository` in new `Repositories` namespace
- simplify `BitvavoApi.GetCandleData` to only call the API
- load candles via `CandleRepository` in `BitBetMaticProcessor` and `DataLoader`
- inject repository into backtesting utilities and Azure functions

## Testing
- `dotnet build BitBetMaticFunctions.csproj -v q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685922aa88e88323a145d5e834a06546