### PR TITLE
Refactor persistence boundary for Epic 0002 and add targeted tests

### DIFF
--- a/BitBetMatic.Tests/BitBetMatic.Tests.csproj
+++ b/BitBetMatic.Tests/BitBetMatic.Tests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\BitBetMatic\BitBetMaticFunctions.csproj" />
+  </ItemGroup>
+</Project>

--- a/BitBetMatic.Tests/CandleRepositoryTests.cs
+++ b/BitBetMatic.Tests/CandleRepositoryTests.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using BitBetMatic.API;
+using BitBetMatic.Repositories;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+public class CandleRepositoryTests
+{
+    [Fact]
+    public async Task AddCandlesAsync_DoesNotInsertDuplicateMarketDateRows()
+    {
+        var dbName = Guid.NewGuid().ToString("N");
+        var factory = CreateFactory(dbName);
+        var repository = new CandleRepository(factory);
+
+        var candle = CreateCandle("BTC-EUR", new DateTime(2025, 1, 1, 10, 0, 0, DateTimeKind.Utc));
+
+        await repository.AddCandlesAsync(new[] { candle });
+        await repository.AddCandlesAsync(new[] { CreateCandle(candle.Market, candle.Date) });
+
+        await using var context = await factory.CreateDbContextAsync();
+        Assert.Equal(1, await context.Candles.CountAsync());
+    }
+
+    [Fact]
+    public async Task GetCandlesAsync_ReturnsSortedCandlesWithinRange()
+    {
+        var dbName = Guid.NewGuid().ToString("N");
+        var factory = CreateFactory(dbName);
+        var repository = new CandleRepository(factory);
+
+        await repository.AddCandlesAsync(new List<FlaggedQuote>
+        {
+            CreateCandle("ETH-EUR", new DateTime(2025, 1, 1, 11, 0, 0, DateTimeKind.Utc)),
+            CreateCandle("ETH-EUR", new DateTime(2025, 1, 1, 10, 0, 0, DateTimeKind.Utc))
+        });
+
+        var result = await repository.GetCandlesAsync(
+            "ETH-EUR",
+            new DateTime(2025, 1, 1, 9, 0, 0, DateTimeKind.Utc),
+            new DateTime(2025, 1, 1, 12, 0, 0, DateTimeKind.Utc));
+
+        Assert.Equal(2, result.Count);
+        Assert.True(result[0].Date < result[1].Date);
+    }
+
+    private static IDbContextFactory<TradingDbContext> CreateFactory(string dbName)
+    {
+        var options = new DbContextOptionsBuilder<TradingDbContext>()
+            .UseInMemoryDatabase(dbName)
+            .Options;
+
+        return new PooledDbContextFactory<TradingDbContext>(options);
+    }
+
+    private static FlaggedQuote CreateCandle(string market, DateTime date)
+    {
+        return new FlaggedQuote
+        {
+            Market = market,
+            Date = date,
+            Open = 100,
+            High = 110,
+            Low = 90,
+            Close = 105,
+            Volume = 1
+        };
+    }
+}

--- a/BitBetMatic.Tests/TradingDbContextTests.cs
+++ b/BitBetMatic.Tests/TradingDbContextTests.cs
@@ -1,0 +1,22 @@
+using System;
+using Xunit;
+
+public class TradingDbContextTests
+{
+    [Fact]
+    public void GetRequiredConnectionString_ThrowsWhenMissing()
+    {
+        var key = TradingDbContext.ConnectionStringEnvironmentVariable;
+        var previous = Environment.GetEnvironmentVariable(key);
+
+        try
+        {
+            Environment.SetEnvironmentVariable(key, null);
+            Assert.Throws<InvalidOperationException>(() => TradingDbContext.GetRequiredConnectionString());
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(key, previous);
+        }
+    }
+}

--- a/BitBetMatic/BitBetMaticFunction.cs
+++ b/BitBetMatic/BitBetMaticFunction.cs
@@ -9,7 +9,6 @@ using BitBetMatic.API;
 using BitBetMatic.Repositories;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Skender.Stock.Indicators;
 
@@ -31,11 +30,6 @@ namespace BitBetMatic
         public async Task<HttpResponseData> Run(
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post", Route = null)] HttpRequestData req, FunctionContext funcContext)
         {
-            using (var context = new TradingDbContext())
-            {
-                context.Database.Migrate();
-            }
-
             // var _logger = funcContext.GetLogger();
 
             // Console.WriteLine("C# HTTP trigger function processed a request.");
@@ -66,11 +60,6 @@ namespace BitBetMatic
         [Function("BitBetMaticBackTesting")]
         public async Task RunAsync([TimerTrigger("0 */15 * * * *")] TimerInfo timer)
         {
-            using (var context = new TradingDbContext())
-            {
-                context.Database.Migrate();
-            }
-
             Console.WriteLine("C# HTTP trigger function processed a request.");
             await new BitBetMaticBackTestingOnDemand(CandleRepository).BackTestVariants();
             // await FindPatterns();
@@ -88,11 +77,6 @@ namespace BitBetMatic
         [Function("BitBetMaticBackTestingOnDemand")]
         public async Task<HttpResponseData> Run([HttpTrigger(AuthorizationLevel.Anonymous, "get", "post", Route = null)] HttpRequestData req)
         {
-            using (var context = new TradingDbContext())
-            {
-                context.Database.Migrate();
-            }
-
             Console.WriteLine("C# HTTP trigger function processed a request.");
             await BackTestVariants();
             // await FindPatterns();
@@ -224,14 +208,9 @@ namespace BitBetMatic
         [Function("BitBetMaticFunction")]
         public async Task RunAsync([TimerTrigger("0 */15 * * * *")] TimerInfo timer)
         {
-            using (var context = new TradingDbContext())
-            {
-                context.Database.Migrate();
-            }
-
             Console.WriteLine($"C# Timer trigger function executed at: {DateTime.Now}");
             var sb = new StringBuilder();
-            BitBetMaticProcessor bitBetMaticProcessor = new BitBetMaticProcessor(new BitvavoApi(CandleRepository), new CandleRepository());
+            BitBetMaticProcessor bitBetMaticProcessor = new BitBetMaticProcessor(new BitvavoApi(CandleRepository), CandleRepository);
             var backtestResult = await bitBetMaticProcessor.RunBacktesting(sb);
 
             Console.WriteLine($"backtestResult: btcStrategy: {backtestResult.strategyBtc.GetType()}, ethStrategy: {backtestResult.strategyEth.GetType()}");

--- a/BitBetMatic/Persistency/IndicatorThresholdPersistency.cs
+++ b/BitBetMatic/Persistency/IndicatorThresholdPersistency.cs
@@ -5,49 +5,61 @@ using Microsoft.EntityFrameworkCore;
 
 public class IndicatorThresholdPersistency
 {
+    private readonly IDbContextFactory<TradingDbContext> _dbContextFactory;
+
+    public IndicatorThresholdPersistency() : this(new PooledDbContextFactory<TradingDbContext>(
+        new DbContextOptionsBuilder<TradingDbContext>()
+            .UseSqlServer(TradingDbContext.GetRequiredConnectionString())
+            .Options))
+    {
+    }
+
+    public IndicatorThresholdPersistency(IDbContextFactory<TradingDbContext> dbContextFactory)
+    {
+        _dbContextFactory = dbContextFactory;
+    }
+
     public async Task InsertThresholdsAsync(IndicatorThresholds thresholds)
     {
         thresholds.Id = 0;
-        thresholds.CreatedAt = DateTime.Now;
+        thresholds.CreatedAt = DateTime.UtcNow;
         await SaveThresholdsAsync(thresholds);
     }
 
     public async Task SaveThresholdsAsync(IndicatorThresholds thresholds)
     {
-        using (var context = new TradingDbContext())
-        {
-            Console.WriteLine($"Saving new thresholds for {thresholds.Strategy} with a score of {thresholds.Highscore}");
-            context.IndicatorThresholds.Add(thresholds);
-            await context.SaveChangesAsync();
-        }
+        await using var context = await _dbContextFactory.CreateDbContextAsync();
+
+        Console.WriteLine($"Saving new thresholds for {thresholds.Strategy} with a score of {thresholds.Highscore}");
+        context.IndicatorThresholds.Add(thresholds);
+        await context.SaveChangesAsync();
     }
 
     public async Task<IndicatorThresholds> GetLatestThresholdsAsync(string strategy, string market)
     {
-        using (var context = new TradingDbContext())
-        {
-            return await context.IndicatorThresholds
-                .Where(t => t.Strategy == strategy && t.Market == market)
-                .OrderByDescending(t => t.CreatedAt)
-                .FirstOrDefaultAsync();
-        }
+        await using var context = await _dbContextFactory.CreateDbContextAsync();
+
+        return await context.IndicatorThresholds
+            .Where(t => t.Strategy == strategy && t.Market == market)
+            .OrderByDescending(t => t.CreatedAt)
+            .FirstOrDefaultAsync();
     }
+
     public async Task<IndicatorThresholds> GetLatestDecayedThresholdsAsync(string strategy, string market, double decayRate)
     {
-        using (var context = new TradingDbContext())
+        var bestThresholds = await GetLatestThresholdsAsync(strategy, market);
+
+        if (bestThresholds == null)
         {
-            // Calculate DecayScore based on the age of the thresholds and Highscore
-            var bestThresholds = await GetLatestThresholdsAsync(strategy, market);
-
-            if (bestThresholds == null) return null;
-
-            Console.WriteLine($"Raw highscore for {strategy} {market}: {bestThresholds?.Highscore ?? 0}");
-
-            bestThresholds.Highscore = bestThresholds.Highscore * (decimal)Math.Exp(-decayRate * (DateTime.Now - bestThresholds.CreatedAt).TotalDays); // Decay score calculation
-
-            Console.WriteLine($"Decayed highscore for {strategy} {market}: {bestThresholds.Highscore}");
-
-            return bestThresholds; // Return the best thresholds
+            return null;
         }
+
+        Console.WriteLine($"Raw highscore for {strategy} {market}: {bestThresholds.Highscore}");
+
+        bestThresholds.Highscore *= (decimal)Math.Exp(-decayRate * (DateTime.UtcNow - bestThresholds.CreatedAt).TotalDays);
+
+        Console.WriteLine($"Decayed highscore for {strategy} {market}: {bestThresholds.Highscore}");
+
+        return bestThresholds;
     }
 }

--- a/BitBetMatic/Persistency/MigrationHostedService.cs
+++ b/BitBetMatic/Persistency/MigrationHostedService.cs
@@ -1,0 +1,22 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Hosting;
+
+public sealed class MigrationHostedService : IHostedService
+{
+    private readonly IDbContextFactory<TradingDbContext> _dbContextFactory;
+
+    public MigrationHostedService(IDbContextFactory<TradingDbContext> dbContextFactory)
+    {
+        _dbContextFactory = dbContextFactory;
+    }
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        await using var context = await _dbContextFactory.CreateDbContextAsync(cancellationToken);
+        await context.Database.MigrateAsync(cancellationToken);
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/BitBetMatic/Persistency/README.md
+++ b/BitBetMatic/Persistency/README.md
@@ -1,0 +1,26 @@
+# Persistence notes (Epic 0002 / Features 1-2)
+
+## Scope
+This folder contains persistence concerns for:
+- candle storage/retrieval (Feature 1)
+- strategy threshold persistence (Feature 2)
+
+No Feature 3 responsibilities should be added here.
+
+## Conventions
+- `TradingDbContext` is the single EF Core boundary for app data access.
+- Connection string is read from `DB_CONNECTION_STRING` and must be configured in the runtime environment.
+- Schema migrations run at host startup through `MigrationHostedService`.
+- Repositories should consume `IDbContextFactory<TradingDbContext>` and must not `new` a `TradingDbContext` directly.
+
+## Migration setup
+Design-time migration commands rely on `TradingDbContextFactory`, which uses the same `DB_CONNECTION_STRING` setting as runtime.
+
+Example:
+```bash
+dotnet ef migrations add <Name> --project BitBetMatic/BitBetMaticFunctions.csproj
+```
+
+## Deferred by design
+- Upsert support at database level (MERGE/SPROC) is intentionally deferred.
+- Historical threshold archiving/cleanup policy is intentionally deferred.

--- a/BitBetMatic/Persistency/TradingDbContext.cs
+++ b/BitBetMatic/Persistency/TradingDbContext.cs
@@ -4,18 +4,28 @@ using Microsoft.EntityFrameworkCore;
 
 public class TradingDbContext : DbContext
 {
+    public const string ConnectionStringEnvironmentVariable = "DB_CONNECTION_STRING";
+
+    public TradingDbContext(DbContextOptions<TradingDbContext> options) : base(options)
+    {
+    }
+
+    // Parameterless constructor is kept for existing call sites and EF design-time tooling.
+    public TradingDbContext()
+    {
+    }
+
     public DbSet<IndicatorThresholds> IndicatorThresholds { get; set; }
     public DbSet<FlaggedQuote> Candles { get; set; }
 
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {
-        var connectionString = "Server=tcp:bitbetmatic-db.database.windows.net,1433;Initial Catalog=bitbetmatic-db;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;Authentication=\"Active Directory Default\";";
-        if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable("DB_CONNECTION_STRING")))
+        if (optionsBuilder.IsConfigured)
         {
-            throw new InvalidOperationException("Database connection string is not set.");
+            return;
         }
-        
-        // Verbind met Azure SQL Database
+
+        var connectionString = GetRequiredConnectionString();
         optionsBuilder.UseSqlServer(connectionString);
     }
 
@@ -23,8 +33,20 @@ public class TradingDbContext : DbContext
     {
         base.OnModelCreating(modelBuilder);
 
-        // Indexen voor betere query-prestaties
         modelBuilder.Entity<IndicatorThresholds>()
             .HasIndex(e => new { e.Strategy, e.Market, e.CreatedAt });
+
+    }
+
+    public static string GetRequiredConnectionString()
+    {
+        var connectionString = Environment.GetEnvironmentVariable(ConnectionStringEnvironmentVariable);
+        if (string.IsNullOrWhiteSpace(connectionString))
+        {
+            throw new InvalidOperationException(
+                $"Database connection string is not set. Configure environment variable '{ConnectionStringEnvironmentVariable}'.");
+        }
+
+        return connectionString;
     }
 }

--- a/BitBetMatic/Persistency/TradingDbContextFactory.cs
+++ b/BitBetMatic/Persistency/TradingDbContextFactory.cs
@@ -1,9 +1,13 @@
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Design;
 
 public class TradingDbContextFactory : IDesignTimeDbContextFactory<TradingDbContext>
 {
     public TradingDbContext CreateDbContext(string[] args)
     {
-        return new TradingDbContext();
+        var optionsBuilder = new DbContextOptionsBuilder<TradingDbContext>();
+        optionsBuilder.UseSqlServer(TradingDbContext.GetRequiredConnectionString());
+
+        return new TradingDbContext(optionsBuilder.Options);
     }
 }

--- a/BitBetMatic/Program.cs
+++ b/BitBetMatic/Program.cs
@@ -1,5 +1,6 @@
 using BitBetMatic.API;
 using BitBetMatic.Repositories;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
@@ -11,9 +12,14 @@ var host = new HostBuilder()
     })
     .ConfigureServices(services =>
     {
+        services.AddDbContextFactory<TradingDbContext>(options =>
+            options.UseSqlServer(TradingDbContext.GetRequiredConnectionString()));
+
+        services.AddHostedService<MigrationHostedService>();
+
         services.AddTransient<ICandleRepository, CandleRepository>();
         services.AddTransient<IApiWrapper, BitvavoApi>();
     })
     .Build();
-    
+
 host.Run();

--- a/BitBetMatic/Repositories/CandleRepository.cs
+++ b/BitBetMatic/Repositories/CandleRepository.cs
@@ -7,18 +7,24 @@ using Microsoft.EntityFrameworkCore;
 
 namespace BitBetMatic.Repositories
 {
-
     public interface ICandleRepository
     {
         Task<List<FlaggedQuote>> GetCandlesAsync(string market, DateTime start, DateTime end);
         Task AddCandlesAsync(IEnumerable<FlaggedQuote> candles);
-
     }
-    public class CandleRepository: ICandleRepository
+
+    public class CandleRepository : ICandleRepository
     {
+        private readonly IDbContextFactory<TradingDbContext> _dbContextFactory;
+
+        public CandleRepository(IDbContextFactory<TradingDbContext> dbContextFactory)
+        {
+            _dbContextFactory = dbContextFactory;
+        }
+
         public async Task<List<FlaggedQuote>> GetCandlesAsync(string market, DateTime start, DateTime end)
         {
-            using var context = new TradingDbContext();
+            await using var context = await _dbContextFactory.CreateDbContextAsync();
             start = DateTime.SpecifyKind(start, DateTimeKind.Utc);
             end = DateTime.SpecifyKind(end, DateTimeKind.Utc);
 
@@ -30,8 +36,51 @@ namespace BitBetMatic.Repositories
 
         public async Task AddCandlesAsync(IEnumerable<FlaggedQuote> candles)
         {
-            using var context = new TradingDbContext();
-            await context.Candles.AddRangeAsync(candles);
+            var incomingCandles = candles
+                .Where(c => c is not null)
+                .Select(c =>
+                {
+                    c.Date = DateTime.SpecifyKind(c.Date, DateTimeKind.Utc);
+                    return c;
+                })
+                .ToList();
+
+            if (incomingCandles.Count == 0)
+            {
+                return;
+            }
+
+            await using var context = await _dbContextFactory.CreateDbContextAsync();
+
+            var marketGroups = incomingCandles
+                .Where(c => !string.IsNullOrWhiteSpace(c.Market))
+                .GroupBy(c => c.Market);
+
+            var existingByMarket = new Dictionary<string, HashSet<DateTime>>();
+            foreach (var group in marketGroups)
+            {
+                var minDate = group.Min(c => c.Date);
+                var maxDate = group.Max(c => c.Date);
+
+                var existingDates = await context.Candles
+                    .Where(c => c.Market == group.Key && c.Date >= minDate && c.Date <= maxDate)
+                    .Select(c => c.Date)
+                    .ToListAsync();
+
+                existingByMarket[group.Key] = existingDates.ToHashSet();
+            }
+
+            var candlesToAdd = incomingCandles
+                .Where(c => !string.IsNullOrWhiteSpace(c.Market))
+                .Where(c => !existingByMarket[c.Market].Contains(c.Date))
+                .ToList();
+
+            if (candlesToAdd.Count == 0)
+            {
+                return;
+            }
+
+            await context.Candles.AddRangeAsync(candlesToAdd);
             await context.SaveChangesAsync();
         }
     }

--- a/Crypto.sln
+++ b/Crypto.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.5.002.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BitBetMatic", "BitBetMatic\BitBetMaticFunctions.csproj", "{D6363BC6-74F0-4694-AE1D-AC469F7BF663}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BitBetMatic.Tests", "BitBetMatic.Tests\BitBetMatic.Tests.csproj", "{A5B3BB8E-0B12-4E41-B4AA-9B3E2DD204D3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,7 +17,11 @@ Global
 		{D6363BC6-74F0-4694-AE1D-AC469F7BF663}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D6363BC6-74F0-4694-AE1D-AC469F7BF663}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D6363BC6-74F0-4694-AE1D-AC469F7BF663}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+		{A5B3BB8E-0B12-4E41-B4AA-9B3E2DD204D3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A5B3BB8E-0B12-4E41-B4AA-9B3E2DD204D3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A5B3BB8E-0B12-4E41-B4AA-9B3E2DD204D3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A5B3BB8E-0B12-4E41-B4AA-9B3E2DD204D3}.Release|Any CPU.Build.0 = Release|Any CPU
+EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection


### PR DESCRIPTION
### Motivation
- Remove hardcoded connection details and centralize DB configuration to avoid leaking infrastructure concerns into business code.
- Move migration execution out of function handlers into host startup to prevent repeated runtime migrations and reduce overengineering.
- Tighten repository responsibilities to avoid generic-repository anti-patterns and prevent duplicate candle inserts for Feature 1.

### Description
- Reworked `TradingDbContext` to read connection string from `DB_CONNECTION_STRING`, added an options-based constructor and `GetRequiredConnectionString()` guard, and adjusted model configuration. (`Persistency/TradingDbContext.cs`)
- Implemented `TradingDbContextFactory` that configures EF with the same runtime connection string for design-time migrations, and registered an `IDbContextFactory` in `Program.cs` with a `MigrationHostedService` that runs `Database.MigrateAsync()` at host startup. (`Persistency/TradingDbContextFactory.cs`, `Program.cs`, `Persistency/MigrationHostedService.cs`)
- Refactored `CandleRepository` to consume `IDbContextFactory<TradingDbContext>`, normalize UTC datetimes, and perform range-aware duplicate-checking per `(Market, Date)` before inserting to prevent duplicate rows. (`Repositories/CandleRepository.cs`)
- Made `IndicatorThresholdPersistency` DI-friendly, switched to UTC timestamps, and applied decay logic using UTC; removed direct `new TradingDbContext()` usages across persistence. (`Persistency/IndicatorThresholdPersistency.cs`)
- Removed scattered `Database.Migrate()` calls from function handlers and stopped manually constructing repository instances inside functions; functions now use injected services. (`BitBetMaticFunction.cs`)
- Added `Persistency/README.md` documenting scope, conventions, migration setup and intentionally deferred items, and added a test project with focused unit tests for candle deduplication and connection-string guard. (`Persistency/README.md`, `BitBetMatic.Tests/*`)

### Testing
- Added a unit test project (`BitBetMatic.Tests`) with `xUnit` and `Microsoft.EntityFrameworkCore.InMemory` and tests covering candle deduplication and sorted retrieval (`CandleRepositoryTests`) and the connection-string guard (`TradingDbContextTests`).
- The tests are present in the repo and can be run with `dotnet test` in a runtime that has the SDK installed; they were not executed here because `dotnet` was not available in the execution environment.
- Static checks and quick searches were run to confirm removal of inline `Database.Migrate()` and `new TradingDbContext()` call sites.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf8bc7829083238951261b422f50a5)