### PR TITLE
Add Bitvavo legacy integration reference package

### DIFF
--- a/docs/references/bitvavo-legacy/README.md
+++ b/docs/references/bitvavo-legacy/README.md
@@ -1,0 +1,37 @@
+# Bitvavo Legacy Reference (BitBetMatic v1)
+
+## Purpose
+This folder captures the current Bitvavo integration behavior in BitBetMatic v1.
+
+It exists to support migration planning and implementation design for BitBetMatic 2.0.
+
+## Scope
+This package is **reference-only**:
+- It describes what v1 does today.
+- It extracts compact snippets from the legacy code.
+- It highlights known gaps, risks, and architectural issues.
+
+It does **not** introduce new runtime code.
+
+## How to use this in BitBetMatic 2.0
+1. Start with `capabilities.md` to see what appears proven vs uncertain.
+2. Use `api-surface.md` to understand operations, payload shapes, and auth behavior.
+3. Use `migration-notes.md` to decide what to keep as concepts and what to redesign.
+4. Read `risks-and-gotchas.md` before implementing production flows.
+5. Consult `snippets/` only as quick reference patterns.
+
+## Important warning
+Do **not** copy v1 code blindly into 2.0.
+
+Several parts are tightly coupled, use dynamic JSON parsing, mix sync/async patterns, and rely on implicit assumptions (timestamp source, response ordering, numeric precision, and order-size behavior). These should be redesigned for a robust 2.0 exchange layer.
+
+## Primary source files reviewed
+- `BitBetMatic/API/BitvavoApi.cs`
+- `BitBetMatic/API/IApiWrapper.cs`
+- `BitBetMatic/BitBetMaticProcessor.cs`
+- `BitBetMatic/Backtesting/Dataloader.cs`
+- `BitBetMatic/Repositories/CandleRepository.cs`
+- `BitBetMatic/Models/Balance.cs`
+- `BitBetMatic/Models/MarketData.cs`
+- `BitBetMatic/Backtesting/BitvavoPerformanceFunction.cs`
+- `BitBetMatic/Program.cs`

--- a/docs/references/bitvavo-legacy/api-surface.md
+++ b/docs/references/bitvavo-legacy/api-surface.md
@@ -1,0 +1,95 @@
+# Bitvavo v1 API Surface (Implementation-Oriented)
+
+This document describes the exchange operations that the v1 code appears to call.
+
+## 1) Base clients and routing assumptions
+
+- Main REST client uses `API_BASE_URL` env var (`RestClient(Environment.GetEnvironmentVariable("API_BASE_URL"))`).
+- Most exchange calls are relative paths against that base URL.
+- One call (`GetMarkets`) uses a hardcoded secondary host: `https://edge.bitvavo.com` with path `exchange/proxy/v3/markets/data`.
+
+## 2) Authentication and signing
+
+### Header set in signed requests
+For signed endpoints, v1 sets:
+- `Bitvavo-Access-Key`
+- `Bitvavo-Access-Signature`
+- `Bitvavo-Access-Timestamp`
+- `Bitvavo-Access-Window: 60000`
+- `Content-Type: application/json`
+
+### Timestamp behavior
+- Timestamp is fetched from server `GET time` and used as string value.
+- Signing and timestamp header are coupled through this retrieved timestamp.
+
+### Signature construction
+- Prehash format: `timestamp + method + "/v2/" + url + body`
+- HMAC-SHA256 with `BITVAVO_API_SECRET`
+- Output as lowercase hex.
+
+## 3) Operations in `IApiWrapper` / `BitvavoApi`
+
+### 3.1 `GetPrice(market)`
+- Endpoint pattern: `GET ticker/price?market={market}`
+- Parsing: `dynamic`, expects `price` field.
+- Returns `decimal`.
+
+### 3.2 `GetCandleData(market, interval, limit, start, end)`
+- Endpoint pattern: `GET {market}/candles`
+- Query params:
+  - `interval` (e.g. `15m`, `1h`)
+  - `limit`
+  - `start` (Unix ms)
+  - `end` (Unix ms)
+- Response parsing expects array rows with indices:
+  - `[0]` timestamp ms
+  - `[1]` open
+  - `[2]` high
+  - `[3]` low
+  - `[4]` close
+  - `[5]` volume
+- Maps to `FlaggedQuote` (`Quote` extension + `Market`, `TradeAction`, `Id`).
+
+### 3.3 `GetBalances()`
+- Endpoint pattern: signed `GET balance`
+- Parsing target: `List<Balance>` where model uses lower-case property names (`symbol`, `available`, `inOrder`).
+
+### 3.4 `Buy(market, amount)` / `Sell(market, amount)`
+- Implemented via private `PlaceOrder`.
+- Endpoint pattern: signed `POST order`
+- Request JSON body shape:
+  - `market`
+  - `side`
+  - `orderType: "market"`
+  - `amountQuote` (formatted as string, usually 2 decimals)
+- Success parsing: `dynamic`, reads `orderId`.
+
+### 3.5 `GetTradeData(market)`
+- Endpoint pattern: signed `GET trades/?market={market}`
+- Parsing target: `List<TradeData>` with fields like `Id`, `OrderId`, `Timestamp`, `Amount`, `Price`, etc.
+- Utility conversion: `TimestampAsDateTime` from Unix ms.
+
+### 3.6 `GetMarkets()`
+- Endpoint pattern: `GET https://edge.bitvavo.com/exchange/proxy/v3/markets/data?miniChart=false`
+- Parsing target: `List<MarketData>` with nested `Base` and `Quote`.
+
+### 3.7 `GetPortfolioData()`
+- Not implemented (`NotImplementedException`).
+
+## 4) Key data models and DTO shape notes
+
+- `Balance`: `symbol` (string), `available` (decimal), `inOrder` (string).
+- `TradeData`: mostly typed scalar fields; includes computed UTC date conversion.
+- `MarketData`: mixed numeric types (`double`, `int`, `object` for `HighlightedAt`).
+- `FlaggedQuote`: inherits indicator-library `Quote` and adds app-specific metadata.
+
+## 5) Behavioral assumptions encoded in v1
+
+- Candle granularity helper `Get15MinuteIntervals` always divides by 15 minutes, regardless of requested interval string.
+- Candle fetching logic paginates by moving `end` backward to earliest fetched candle minus 1 second.
+- Order amount precision is mostly fixed to 2 decimals unless amount is whole number.
+- Error handling relies on thrown generic `Exception` with response body text.
+
+## 6) Security note
+
+The implementation expects API key/secret values via environment variables. Sensitive values are not copied into this reference package.

--- a/docs/references/bitvavo-legacy/capabilities.md
+++ b/docs/references/bitvavo-legacy/capabilities.md
@@ -1,0 +1,49 @@
+# Bitvavo v1 Capabilities
+
+Status legend used below:
+- **Observed in code**: directly visible in current implementation.
+- **Inferred from code paths**: likely behavior, but not fully proven by tests in this repository.
+- **Unknown / unverified**: not enough evidence in code/tests.
+
+## Confirmed capabilities (observed in code)
+
+### Public market data
+- Fetch current ticker price for a market via `ticker/price?market=...`.
+- Fetch candles via `{market}/candles` with `interval`, `limit`, `start`, `end` (milliseconds).
+- Convert candle timestamps from Unix milliseconds to UTC `DateTime`.
+
+### Authenticated account and trading calls
+- Fetch balances via authenticated `GET balance`.
+- Place market buy/sell orders via authenticated `POST order` using:
+  - `market`
+  - `side` (`buy`/`sell`)
+  - `orderType = market`
+  - `amountQuote` (formatted string)
+- Fetch authenticated trade history via `GET trades/?market=...`.
+
+### Signature/auth mechanics
+- Create Bitvavo headers using env vars:
+  - `BITVAVO_API_KEY`
+  - `BITVAVO_API_SECRET`
+  - `API_BASE_URL`
+- Signature prehash format in v1: `{timestamp}{method}/v2/{url}{body}`.
+- Signature algorithm: HMAC-SHA256 hex lowercase.
+- Timestamp is retrieved by calling Bitvavo `GET time` per signed request setup.
+
+### Candle persistence integration
+- Candle data is cached in database through `ICandleRepository`.
+- Duplicate prevention is done by `(market, date)` checks at repository level.
+- DataLoader can fetch missing historical ranges from Bitvavo and persist only missing candles.
+
+## Likely capabilities (inferred from code paths)
+- Scheduled and HTTP-triggered functions use `BitvavoApi` through DI/manual instantiation.
+- Trading strategy loop can execute live buy/sell when `transact=true`.
+- Market metadata retrieval (`GetMarkets`) is intended for market selection, although currently not central in active strategy flow.
+
+## Unclear / partially implemented / legacy-only
+- `GetPortfolioData()` in `IApiWrapper` is not implemented in `BitvavoApi`.
+- Retry/backoff is not explicitly implemented for Bitvavo HTTP failures.
+- Formal rate-limit handling is absent.
+- Typed DTO coverage is partial; several endpoints use `dynamic` parsing.
+- `GetMarketInfo` exists but is private and unused from outside `BitvavoApi`.
+- Some analysis/performance code uses `.Result` on async calls (legacy style), which may hide runtime issues under load.

--- a/docs/references/bitvavo-legacy/code-snippets.md
+++ b/docs/references/bitvavo-legacy/code-snippets.md
@@ -1,0 +1,37 @@
+# Code Snippets Guide (Legacy Bitvavo)
+
+This file explains what each extracted snippet demonstrates and how to use it safely for BitBetMatic 2.0 planning.
+
+## Snippet index
+
+- `snippets/auth-signing-example.cs`
+  - Demonstrates v1 signing prehash + HMAC flow and header composition.
+  - Source: `BitBetMatic/API/BitvavoApi.cs`.
+
+- `snippets/candle-fetch-example.cs`
+  - Demonstrates v1 candle request parameters, response row mapping, UTC conversion, and paging behavior.
+  - Source: `BitBetMatic/API/BitvavoApi.cs`.
+
+- `snippets/order-placement-example.cs`
+  - Demonstrates v1 market order body creation and response parsing (`orderId`).
+  - Source: `BitBetMatic/API/BitvavoApi.cs`.
+
+## How to interpret these snippets
+
+- They are **historical implementation references**, not drop-in code.
+- They intentionally preserve legacy choices that may need redesign.
+- They are compact to make key ideas easy to inspect quickly.
+
+## What these snippets are useful for
+
+- Reconstructing v1 request/response expectations.
+- Understanding existing naming and field conventions.
+- Preserving migration context for AI agents and humans.
+
+## What not to copy directly
+
+- Dynamic JSON parsing (`dynamic`) for production-critical flows.
+- Generic `Exception` throwing without typed error contracts.
+- Fixed precision assumptions for `amountQuote`.
+- Interval calculations that assume 15-minute candles for all intervals.
+- Any coupling that causes repeated `GET time` calls per signed request.

--- a/docs/references/bitvavo-legacy/migration-notes.md
+++ b/docs/references/bitvavo-legacy/migration-notes.md
@@ -1,0 +1,122 @@
+# Migration Notes for BitBetMatic 2.0 (from v1 Bitvavo integration)
+
+## Principles
+- Treat v1 as behavior reference, not architecture template.
+- Preserve business intent, redesign integration boundaries.
+- Prefer explicit contracts, typed parsing, and deterministic error behavior.
+
+---
+
+## 1) Candle retrieval
+
+### What existed in v1
+- Candles fetched from `{market}/candles` with `interval`, `limit`, `start`, `end`.
+- Timestamps converted from Unix ms to UTC `DateTime`.
+- DataLoader merges database candles with fetched candles and stores only missing entries.
+
+### What is reusable
+- General pattern of cache-first historical loading.
+- Explicit UTC normalization before persistence.
+- De-duplication strategy using market + timestamp identity.
+
+### What must change in 2.0
+- Replace interval math helper that assumes 15-minute granularity.
+- Define a clear pagination strategy independent of response ordering assumptions.
+- Introduce typed response models instead of dynamic row indexing where feasible.
+- Add resilient retry/backoff and rate-limit-aware request policy.
+
+---
+
+## 2) Auth/signing
+
+### What existed in v1
+- HMAC-SHA256 signature over `{timestamp}{method}/v2/{url}{body}`.
+- Timestamp fetched via `GET time`, then reused in signed headers.
+- Credentials loaded from environment variables.
+
+### What is reusable
+- Core prehash/signature pattern and header names.
+- Secret isolation via environment/config injection.
+
+### What must change in 2.0
+- Move signing into isolated, testable auth component.
+- Add deterministic canonicalization tests for signature payload.
+- Avoid hidden network coupling when creating signatures (timestamp strategy should be explicit and controllable).
+- Introduce secret-safe diagnostics (never log or serialize secrets).
+
+---
+
+## 3) Order placement
+
+### What existed in v1
+- Single order path: market order with `amountQuote`.
+- Buy/sell wrappers call shared `PlaceOrder`.
+- Success path returns formatted string including `orderId`.
+
+### What is reusable
+- Shared internal order execution flow for buy/sell.
+- High-level request shape (`market`, `side`, `orderType`, `amountQuote`).
+
+### What must change in 2.0
+- Return typed order result object (status, ids, exchange payload metadata).
+- Implement instrument-specific precision/step-size handling.
+- Add idempotency/client-order-id strategy if supported.
+- Add explicit handling for partial fills, rejected orders, and transient failures.
+
+---
+
+## 4) Response parsing
+
+### What existed in v1
+- Mixed typed DTOs and `dynamic` parsing.
+- Candle rows parsed by numeric index positions.
+
+### What is reusable
+- Existing DTO names and rough shape are useful migration hints.
+
+### What must change in 2.0
+- Replace dynamic parsing in critical paths with typed contracts and validation.
+- Add tolerant parsing with schema drift handling where needed.
+- Centralize serialization settings and number/date parsing rules.
+
+---
+
+## 5) Error handling and reliability
+
+### What existed in v1
+- Failures generally throw generic `Exception` with response content.
+- Minimal warning logs; no structured retry policy.
+- Some code paths mix async with `.Result` in legacy utilities.
+
+### What is reusable
+- Basic intent to surface upstream response bodies for diagnostics.
+
+### What must change in 2.0
+- Introduce typed exception hierarchy (auth, rate-limit, transient, validation, exchange rejection).
+- Add retry/backoff/circuit-breaker strategy by endpoint type.
+- Use fully async flows end-to-end.
+- Add request correlation IDs and structured logging.
+
+---
+
+## 6) Exchange abstraction
+
+### What existed in v1
+- `IApiWrapper` combines market data, account data, and trading operations in one interface.
+- Some methods are incomplete (`GetPortfolioData`).
+
+### What is reusable
+- Single adapter entrypoint concept for strategy engine integration.
+
+### What must change in 2.0
+- Split into focused ports/interfaces (market data, account, trading, reference data).
+- Version contracts and make capability discovery explicit.
+- Ensure implementations can be tested with deterministic mocks and fixture payloads.
+
+---
+
+## 7) Inspiration-only areas (do not copy directly)
+- Dynamic JSON access patterns.
+- Implicit assumptions about candle order and interval math.
+- String-only success returns for order placement.
+- Legacy sync-over-async usage patterns.

--- a/docs/references/bitvavo-legacy/risks-and-gotchas.md
+++ b/docs/references/bitvavo-legacy/risks-and-gotchas.md
@@ -1,0 +1,61 @@
+# Risks and Gotchas (Legacy Bitvavo v1)
+
+This list separates what is directly observed from what is inferred risk.
+
+## Observed in code
+
+1. **Interval calculation hardcoded to 15-minute buckets**
+   - `Get15MinuteIntervals` is used to cap fetch `limit` regardless of requested interval string.
+   - Risk: incorrect limits for `1h`, `5m`, etc.
+
+2. **Candle paging relies on response ordering assumption**
+   - Loop updates `end = newQuotes.Min(q => q.Date).AddSeconds(-1)`.
+   - Risk: if API ordering changes, paging may skip or overlap unexpectedly.
+
+3. **Dynamic JSON parsing in critical paths**
+   - Price, candles, and order response fields are read via `dynamic`.
+   - Risk: runtime failures on shape/type drift without compile-time protection.
+
+4. **Generic exceptions without typed categories**
+   - Most failures throw `Exception` with raw response text.
+   - Risk: caller cannot reliably branch on failure class.
+
+5. **Order amount formatting is simplistic**
+   - `amountQuote` uses 2 decimal places unless whole number.
+   - Risk: market-specific precision/min step rules may not be respected.
+
+6. **Additional host dependency for market metadata**
+   - `GetMarkets` uses `https://edge.bitvavo.com` directly.
+   - Risk: behavior differs from `API_BASE_URL`-based routing and signing model.
+
+7. **Partially implemented API abstraction**
+   - `GetPortfolioData` throws `NotImplementedException`.
+   - Risk: interface suggests capability that runtime cannot provide.
+
+## Likely operational risks (inferred)
+
+1. **Rate-limit sensitivity**
+   - No explicit throttle/retry/backoff in BitvavoApi.
+   - Repeated timestamp/time calls for signed requests may increase request count.
+
+2. **Clock/timestamp coupling fragility**
+   - Signing depends on obtaining remote time first.
+   - If `time` endpoint is delayed/failing, authenticated calls may fail indirectly.
+
+3. **Nullability and parse robustness**
+   - Limited defensive checks for missing fields in dynamic payloads.
+   - Could surface as runtime binder/serialization errors.
+
+4. **Sync-over-async legacy usage in ancillary flows**
+   - Some `.Result` usage appears in performance/backtesting code.
+   - Potential deadlock/latency patterns in certain hosts.
+
+## Unknown / unverified areas
+
+- Exact production rate-limit behavior under current Bitvavo limits is not validated here.
+- Formal exchange error-code mapping is not implemented or documented in v1.
+- It is unclear whether all markets used by strategies have uniform precision and minimum order constraints.
+- No direct proof in this repo that all authenticated endpoints were exercised in production recently.
+
+## Sensitive material handling note
+Credentials are consumed from environment variables in code. No secrets are copied into this reference package.

--- a/docs/references/bitvavo-legacy/snippets/auth-signing-example.cs
+++ b/docs/references/bitvavo-legacy/snippets/auth-signing-example.cs
@@ -1,0 +1,25 @@
+// Reference-only legacy snippet.
+// Extracted from BitBetMatic v1 for documentation and migration planning.
+// Not part of the active runtime for BitBetMatic 2.0.
+
+private void SetApiRequestHeaders(RestRequest request, string url, string body = "")
+{
+    var timestamp = GetTime();
+
+    request.AddHeader("Bitvavo-Access-Key", Environment.GetEnvironmentVariable("BITVAVO_API_KEY"));
+    request.AddHeader("Bitvavo-Access-Signature", GenerateSignature(timestamp, request.Method.ToString().ToUpper(), url, body));
+    request.AddHeader("Bitvavo-Access-Timestamp", timestamp);
+    request.AddHeader("Bitvavo-Access-Window", 60000);
+    request.AddHeader("Content-Type", "application/json");
+}
+
+private string GenerateSignature(string timestamp, string method, string url, string body)
+{
+    string prehashString = $"{timestamp}{method}/v2/{url}{body}";
+
+    using (var hmac = new HMACSHA256(Encoding.UTF8.GetBytes(Environment.GetEnvironmentVariable("BITVAVO_API_SECRET"))))
+    {
+        byte[] hashBytes = hmac.ComputeHash(Encoding.UTF8.GetBytes(prehashString));
+        return BitConverter.ToString(hashBytes).Replace("-", "").ToLower();
+    }
+}

--- a/docs/references/bitvavo-legacy/snippets/candle-fetch-example.cs
+++ b/docs/references/bitvavo-legacy/snippets/candle-fetch-example.cs
@@ -1,0 +1,43 @@
+// Reference-only legacy snippet.
+// Extracted from BitBetMatic v1 for documentation and migration planning.
+// Not part of the active runtime for BitBetMatic 2.0.
+
+public async Task<List<FlaggedQuote>> GetCandleData(string market, string interval, int limit, DateTime start, DateTime end)
+{
+    var newQuotes = new List<FlaggedQuote>();
+
+    while (start < end)
+    {
+        limit = Math.Min(limit, Get15MinuteIntervals(start, end));
+        if (limit == 0) return newQuotes;
+
+        var request = new RestRequest($"{market}/candles", Method.Get);
+        request.AddParameter("interval", interval);
+        request.AddParameter("limit", limit);
+        request.AddParameter("start", new DateTimeOffset(start).ToUnixTimeMilliseconds());
+        request.AddParameter("end", new DateTimeOffset(end).ToUnixTimeMilliseconds());
+
+        var response = await Client.ExecuteAsync(request);
+        var candles = JsonConvert.DeserializeObject<dynamic>(response.Content);
+        if (candles == null || candles.Count == 0) break;
+
+        foreach (var candle in candles)
+        {
+            var date = DateTimeOffset.FromUnixTimeMilliseconds((long)candle[0]).UtcDateTime;
+            newQuotes.Add(new FlaggedQuote
+            {
+                Date = DateTime.SpecifyKind(date, DateTimeKind.Utc),
+                Open = (decimal)candle[1],
+                High = (decimal)candle[2],
+                Low = (decimal)candle[3],
+                Close = (decimal)candle[4],
+                Volume = (decimal)candle[5],
+                Market = market
+            });
+        }
+
+        end = newQuotes.Min(q => q.Date).AddSeconds(-1);
+    }
+
+    return newQuotes;
+}

--- a/docs/references/bitvavo-legacy/snippets/order-placement-example.cs
+++ b/docs/references/bitvavo-legacy/snippets/order-placement-example.cs
@@ -1,0 +1,31 @@
+// Reference-only legacy snippet.
+// Extracted from BitBetMatic v1 for documentation and migration planning.
+// Not part of the active runtime for BitBetMatic 2.0.
+
+private async Task<string> PlaceOrder(string market, string side, decimal amount)
+{
+    var formattedAmount = FormatAmount(amount, 2);
+    if (amount % 1 == 0) { formattedAmount = amount.ToString("N0"); }
+
+    var url = "order";
+    var body = new
+    {
+        market,
+        side,
+        orderType = "market",
+        amountQuote = formattedAmount
+    };
+
+    var request = new RestRequest(url, Method.Post);
+    request.AddJsonBody(body);
+    SetApiRequestHeaders(request, url, JsonConvert.SerializeObject(body));
+
+    var response = await Client.ExecuteAsync(request);
+    if (!response.IsSuccessful)
+    {
+        throw new Exception($"Error placing order: {response.Content}");
+    }
+
+    var orderResponse = JsonConvert.DeserializeObject<dynamic>(response.Content);
+    return $"Order {side} placed successfully: {orderResponse.orderId}";
+}


### PR DESCRIPTION
### Motivation
- Capture the existing Bitvavo v1 integration as a structured, reference-only package to support migration planning for BitBetMatic 2.0. 
- Provide clear separation between observed behavior, inferred assumptions, and unknowns without changing production runtime code. 

### Description
- Add a reference folder `docs/references/bitvavo-legacy/` containing `README.md`, `capabilities.md`, `api-surface.md`, `code-snippets.md`, `migration-notes.md`, and `risks-and-gotchas.md`. 
- Extract three compact, non-runtime C# snippets into `snippets/` for auth/signing, candle fetching, and order placement that are explicitly marked as reference-only. 
- Document primary source files reviewed and call out concrete migration guidance (what is reusable vs what must be redesigned) including signing, candle paging, order precision, parsing, and abstraction recommendations. 
- Preserve sensitive handling (describe env var usage) and avoid copying any secret values into the docs.

### Testing
- Ran repository searches with `rg` to locate Bitvavo-related code paths and verify sources, and the searches completed successfully. 
- Opened and inspected key implementation files (`BitvavoApi.cs`, `IApiWrapper.cs`, `Dataloader.cs`, `CandleRepository.cs`, etc.) to inform the documentation. 
- Created the documentation files and committed them successfully with `git add` and `git commit`. 
- No unit or integration tests were modified or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfb4bf7858832387cf2952c9665534)